### PR TITLE
MNT-17640: Log4j is not configured for support tool

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level to error
-log4j.rootLogger=error, Console, File
+log4j.rootLogger=error, Console, File, jmxlogger1
 
 ###### Console appender definition #######
 
@@ -18,6 +18,14 @@ log4j.appender.File.Append=true
 log4j.appender.File.DatePattern='.'yyyy-MM-dd
 log4j.appender.File.layout=org.apache.log4j.PatternLayout
 log4j.appender.File.layout.ConversionPattern=%d{yyyy-MM-dd} %d{ABSOLUTE} %-5p [%c] [%t] %m%n
+
+###### JmxLogger appender definition #######
+log4j.appender.jmxlogger1=jmxlogger.integration.log4j.JmxLogAppender
+log4j.appender.jmxlogger1.layout=org.apache.log4j.PatternLayout
+log4j.appender.jmxlogger1.layout.ConversionPattern=%-5p %c[1] - %m%n
+log4j.appender.jmxlogger1.ObjectName=jmxlogger:type=LogEmitterAlfresco
+log4j.appender.jmxlogger1.threshold=debug
+log4j.appender.jmxlogger1.serverSelection=platform
 
 ###### Hibernate specific appender definition #######
 #log4j.appender.file=org.apache.log4j.FileAppender


### PR DESCRIPTION
   Added jmxlogger1 to log4j.properties files, as they were ommited when support tools was integrated in CS 5.2