### PR TITLE
ALF-21965 Fix ISO8601 format output for dates prior to 1848

### DIFF
--- a/src/main/java/org/alfresco/util/ISO8601DateFormat.java
+++ b/src/main/java/org/alfresco/util/ISO8601DateFormat.java
@@ -58,6 +58,7 @@ import org.joda.time.format.ISODateTimeFormat;
 public class ISO8601DateFormat
 {
     private static ThreadLocal<Map<TimeZone, Calendar>> calendarThreadLocal = new ThreadLocal<Map<TimeZone, Calendar>>();
+    public static final TimeZone UTC_TIMEZONE = TimeZone.getTimeZone("UTC");
     /**
      * Get a calendar object from cache.
      * @return calendar object from cache or newly created (if cache is empty)
@@ -69,11 +70,11 @@ public class ISO8601DateFormat
             calendarThreadLocal.set(new HashMap<TimeZone, Calendar>());
         }
         
-        Calendar calendar = calendarThreadLocal.get().get(TimeZone.getDefault());
+        Calendar calendar = calendarThreadLocal.get().get(UTC_TIMEZONE);
         if (calendar == null)
         {
-            calendar = new GregorianCalendar();
-            calendarThreadLocal.get().put(TimeZone.getDefault(), calendar);
+            calendar = new GregorianCalendar(UTC_TIMEZONE);
+            calendarThreadLocal.get().put(UTC_TIMEZONE, calendar);
         }
         
         return calendar;

--- a/src/main/java/org/alfresco/util/ISO8601DateFormat.java
+++ b/src/main/java/org/alfresco/util/ISO8601DateFormat.java
@@ -135,21 +135,7 @@ public class ISO8601DateFormat
                 formatted.append(val);
             }
 
-            TimeZone tz = calendar.getTimeZone();
-            int offset = tz.getOffset(calendar.getTimeInMillis());
-            if (offset != 0)
-            {
-                int hours = Math.abs((offset / (60 * 1000)) / 60);
-                int minutes = Math.abs((offset / (60 * 1000)) % 60);
-                formatted.append(offset < 0 ? '-' : '+');
-                formatted.append(hours < 10 ? ("0" + hours) : hours);
-                formatted.append(':');
-                formatted.append(minutes < 10 ? ("0" + minutes) : minutes);
-            }
-            else
-            {
-                formatted.append('Z');
-            }
+            formatted.append('Z');
 
             return formatted.toString();
         }

--- a/src/main/java/org/alfresco/util/ISO8601DateFormat.java
+++ b/src/main/java/org/alfresco/util/ISO8601DateFormat.java
@@ -146,6 +146,7 @@ public class ISO8601DateFormat
                 formatted.append(val);
             }
 
+            // ALF-21965 We are now confident we are using UTC timezone with zero offset
             formatted.append('Z');
 
             return formatted.toString();

--- a/src/main/java/org/alfresco/util/ISO8601DateFormat.java
+++ b/src/main/java/org/alfresco/util/ISO8601DateFormat.java
@@ -59,25 +59,36 @@ public class ISO8601DateFormat
 {
     private static ThreadLocal<Map<TimeZone, Calendar>> calendarThreadLocal = new ThreadLocal<Map<TimeZone, Calendar>>();
     public static final TimeZone UTC_TIMEZONE = TimeZone.getTimeZone("UTC");
+
     /**
      * Get a calendar object from cache.
+     * @param timezone timezone object to indicate the timezone to be used by the returned calendar object
      * @return calendar object from cache or newly created (if cache is empty)
      */
-    public static Calendar getCalendar()
+    public static Calendar getCalendar(TimeZone timezone)
     {
         if (calendarThreadLocal.get() == null)
         {
             calendarThreadLocal.set(new HashMap<TimeZone, Calendar>());
         }
         
-        Calendar calendar = calendarThreadLocal.get().get(UTC_TIMEZONE);
+        Calendar calendar = calendarThreadLocal.get().get(timezone);
         if (calendar == null)
         {
-            calendar = new GregorianCalendar(UTC_TIMEZONE);
-            calendarThreadLocal.get().put(UTC_TIMEZONE, calendar);
+            calendar = new GregorianCalendar(timezone);
+            calendarThreadLocal.get().put(timezone, calendar);
         }
         
         return calendar;
+    }
+
+    /**
+     * Get a calendar object from cache for the system default timezone.
+     * @return calendar object from cache or newly created (if cache is empty)
+     */
+    public static Calendar getCalendar()
+    {
+        return getCalendar(TimeZone.getDefault());
     }
     
     /**
@@ -88,7 +99,7 @@ public class ISO8601DateFormat
      */
      public static String format(Date isoDate)
      {
-        Calendar calendar = getCalendar();
+        Calendar calendar = getCalendar(UTC_TIMEZONE);
         calendar.setTime(isoDate);
 
         // MNT-9790

--- a/src/test/java/org/alfresco/util/ISO8601DateFormatTest.java
+++ b/src/test/java/org/alfresco/util/ISO8601DateFormatTest.java
@@ -50,6 +50,24 @@ public class ISO8601DateFormatTest extends TestCase
         assertEquals(date, dateAfter);
         assertEquals(date2, dateAfter2);
     }
+
+    public void testFormat()
+    {
+        TimeZone.setDefault(TimeZone.getTimeZone("PST")); // Any timezone other than UTC
+
+        String strDate1 = "2005-09-16T17:01:03.456Z";
+        String strDate2 = "1801-09-16T17:01:03.456Z";
+        // convert to a date
+        Date date1 = ISO8601DateFormat.parse(strDate1);
+        Date date2 = ISO8601DateFormat.parse(strDate2);
+        // get the string form
+        String strDate1Formatted = ISO8601DateFormat.format(date1);
+        String strDate2Formatted = ISO8601DateFormat.format(date2);
+
+        // Format needs to be in the UTC timezone with zero offset
+        assertEquals(strDate1, strDate1Formatted);
+        assertEquals(strDate2, strDate2Formatted);
+    }
     
     public void testGetCalendarMethod()
     {


### PR DESCRIPTION
Force the use of UTC timezone in ISO8601DateFormat instead of defaulting to server's timezone.
This PR addresses #5 .