### PR TITLE
REPO-3918: Java 11 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC1</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5-REPO-3918_java_11-SNAPSHOT</version>
+   <version>7.5-REPO-3918_java_11</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-     <tag>HEAD</tag>
+     <tag>7.5-REPO-3918_java_11</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>   
       <groupId>org.alfresco</groupId>
       <artifactId>alfresco-super-pom</artifactId>
-      <version>10-RC1</version>
+      <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
    <version>7.5-REPO-3918_java_11-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
          <version>${dependency.surf.version}</version>
       </dependency>
       <dependency>
+         <groupId>javax.xml.bind</groupId>
+         <artifactId>jaxb-api</artifactId>
+         <version>2.3.1</version>
+      </dependency>
+      <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-xjc</artifactId>
          <version>2.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
    <parent>   
       <groupId>org.alfresco</groupId>
       <artifactId>alfresco-super-pom</artifactId>
-      <version>10-SNAPSHOT</version>
+      <version>9-REPO-3918_java_11-SNAPSHOT</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5-SNAPSHOT</version>
+   <version>7.5-REPO-3918_java_11-SNAPSHOT</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -32,8 +32,6 @@
    <properties>
       <dependency.spring.version>5.0.4.RELEASE</dependency.spring.version>
       <dependency.surf.version>6.8</dependency.surf.version>
-
-      <java.compiler.version>11</java.compiler.version>
    </properties>
 
    <dependencies>
@@ -230,7 +228,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.0</version>
             <executions>
                <execution>
                   <goals>
@@ -239,15 +237,6 @@
                </execution>
             </executions>
          </plugin>
-          <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.8.0</version>
-              <configuration>
-                  <source>${java.compiler.version}</source>
-                  <target>${java.compiler.version}</target>
-              </configuration>
-          </plugin>
       </plugins>
    </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5-REPO-3918_java_11-SNAPSHOT</version>
+   <version>7.5-REPO-3918_java_11</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-     <tag>HEAD</tag>
+     <tag>7.5-REPO-3918_java_11</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>   
       <groupId>org.alfresco</groupId>
       <artifactId>alfresco-super-pom</artifactId>
-      <version>9-REPO-3918_java_11-SNAPSHOT</version>
+      <version>10-RC1</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
    <version>7.5-REPO-3918_java_11-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5_REPO_3918_java_11-SNAPSHOT</version>
+   <version>7.5_REPO_3918_java_11</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>HEAD</tag>
+      <tag>7.5_REPO_3918_java_11</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>   
       <groupId>org.alfresco</groupId>
       <artifactId>alfresco-super-pom</artifactId>
-      <version>9</version>
+      <version>10-SNAPSHOT</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
    <version>7.5-SNAPSHOT</version>
@@ -33,7 +33,7 @@
       <dependency.spring.version>5.0.4.RELEASE</dependency.spring.version>
       <dependency.surf.version>6.8</dependency.surf.version>
 
-      <java.compiler.version>1.8</java.compiler.version>
+      <java.compiler.version>11</java.compiler.version>
    </properties>
 
    <dependencies>
@@ -230,7 +230,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>2.6</version>
+            <version>3.0.2</version>
             <executions>
                <execution>
                   <goals>
@@ -242,7 +242,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.6.0</version>
+              <version>3.8.0</version>
               <configuration>
                   <source>${java.compiler.version}</source>
                   <target>${java.compiler.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC1</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5-REPO-3918_java_11</version>
+   <version>7.5-REPO-3918_java_11-SNAPSHOT</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-     <tag>7.5-REPO-3918_java_11</tag>
+     <tag>HEAD</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5_REPO_3918_java_11</version>
+   <version>7.5_REPO_3918_java_11-SNAPSHOT</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>7.5_REPO_3918_java_11</tag>
+      <tag>HEAD</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5-REPO-3918_java_11</version>
+   <version>7.5_REPO_3918_java_11-SNAPSHOT</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-     <tag>7.5-REPO-3918_java_11</tag>
+      <tag>HEAD</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10-RC2</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5_REPO_3918_java_11-SNAPSHOT</version>
+   <version>7.5_REPO_3918_java_11_2</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>HEAD</tag>
+      <tag>7.5_REPO_3918_java_11_2</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -133,17 +133,17 @@
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-xjc</artifactId>
-         <version>2.3.0</version>
+         <version>2.3.1</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-impl</artifactId>
-         <version>2.3.0</version>
+         <version>2.3.1</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-core</artifactId>
-         <version>2.3.0</version>
+         <version>2.3.0.1</version>
       </dependency>
       <dependency>
          <groupId>dom4j</groupId>


### PR DESCRIPTION
* maven-compiler-plugin removed because it is already defined in alfresco-super-pom