### PR TITLE
[ALF-22050] CQ: Allow to recover empty pagings

### DIFF
--- a/src/main/java/org/alfresco/query/AbstractCannedQuery.java
+++ b/src/main/java/org/alfresco/query/AbstractCannedQuery.java
@@ -319,6 +319,9 @@ public abstract class AbstractCannedQuery<R> implements CannedQuery<R>
         }
         else if (firstResult > availableResults)
         {
+            // Add an empty page to show that the query and the paging worked but returned no results
+            List<R> page = new ArrayList<R>(0);
+            pages.add(page);
             return pages;                               // Start of first page is after all results
         }
         

--- a/src/test/java/org/alfresco/query/CannedQueryTest.java
+++ b/src/test/java/org/alfresco/query/CannedQueryTest.java
@@ -208,6 +208,20 @@ public class CannedQueryTest extends TestCase
         assertEquals("Incorrect results on page", 3, pages.get(0).size());
         assertEquals("Incorrect results on page", 3, pages.get(1).size());
         assertTrue("Should have more pages/items", qrOne.hasMoreItems());
+        
+        // Skip all results to get an empty page
+        qPageDetails = new CannedQueryPageDetails(10, 3, 1, 2);
+        params = new CannedQueryParameters(null, qPageDetails, null);
+        qOne = qfOne.getCannedQuery(params);
+        qrOne = qOne.execute();
+        // Check pages
+        assertEquals("Incorrect number of results", 0, qrOne.getPagedResultCount());
+        assertEquals("Incorrect number of pages", 1, qrOne.getPageCount());
+        pages = qrOne.getPages();
+        assertEquals("Incorrect number of pages", 1, pages.size());
+        assertEquals("Incorrect results on page", 0, pages.get(0).size());
+        assertTrue("Should have no more pages/items", !qrOne.hasMoreItems());
+        assertNotNull("Should have one empty page", qrOne.getPage());
     }
     
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Requesting a paging wich does not exist should return either null, either an empty paging which can give the information on the absence of results.
Currently, the only way to know the number of results in a PagingResult is to call `PagingResults#getPage()` .
The problem is that this method throws an exception if the paging has no results when asking an out-of-bound page (for example asking for page two with 10 items in a query which has only 9 results).

Even if most of the time the developer has control over the paging of his request, it is not fundamentally wrong to ask for a not existing paging. It is like making a query which has no results, and in this case no exception is raised.