### PR TITLE
REPO-4244: [6.N] Revert support for OpenJDK 11, back to Oracle JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>9</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>6.21-SNAPSHOT</version>
+   <version>jdk8-1</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>HEAD</tag>
+      <tag>jdk8-1</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <parent>   
       <groupId>org.alfresco</groupId>
       <artifactId>alfresco-super-pom</artifactId>
-      <version>10</version>
+      <version>9</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
    <version>6.21-SNAPSHOT</version>
@@ -33,6 +33,7 @@
       <dependency.spring.version>3.2.16.RELEASE</dependency.spring.version>
       <dependency.surf.version>6.8</dependency.surf.version>
 
+      <java.compiler.version>1.7</java.compiler.version>
    </properties>
 
    <dependencies>
@@ -128,25 +129,20 @@
          <artifactId>spring-surf-core-configservice</artifactId>
          <version>${dependency.surf.version}</version>
       </dependency>
-       <dependency>
-         <groupId>javax.xml.bind</groupId>
-         <artifactId>jaxb-api</artifactId>
-         <version>2.3.1</version>
-      </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-xjc</artifactId>
-         <version>2.3.1</version>
+         <version>2.2.11</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-impl</artifactId>
-         <version>2.3.1</version>
+         <version>2.2.11</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-core</artifactId>
-         <version>2.3.0.1</version>
+         <version>2.2.11</version>
       </dependency>
       <dependency>
          <groupId>dom4j</groupId>
@@ -231,7 +227,7 @@
       <plugins>
          <plugin>
             <artifactId>maven-jar-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>2.6</version>
             <executions>
                <execution>
                   <goals>
@@ -240,6 +236,15 @@
                </execution>
             </executions>
          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.6.0</version>
+              <configuration>
+                  <source>${java.compiler.version}</source>
+                  <target>${java.compiler.version}</target>
+              </configuration>
+          </plugin>
       </plugins>
    </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
       <dependency.spring.version>3.2.16.RELEASE</dependency.spring.version>
       <dependency.surf.version>6.8</dependency.surf.version>
 
-      <java.compiler.version>1.7</java.compiler.version>
+      <java.compiler.version>1.8</java.compiler.version>
    </properties>
 
    <dependencies>


### PR DESCRIPTION
Reverted changes done for Java 11 support in #24.