### PR TITLE
REPO-4504 upgrade cxf-rt-transports-http 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1
 
 install: travis_retry mvn install -DskipTests=true -B -V
 
@@ -35,7 +34,7 @@ jobs:
         - java -jar wss-unified-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c .wss-unified-agent.config
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -44,4 +43,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4504-core-61-1 -DdevelopmentVersion=7.5.6-SNAPSHOT release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
   only:
     - master
     - /support\/.*/
-    - fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1
+    - fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1
 
 install: travis_retry mvn install -DskipTests=true -B -V
 
@@ -35,7 +35,7 @@ jobs:
         - java -jar wss-unified-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c .wss-unified-agent.config
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = fix/REPO-4504_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -44,4 +44,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests 		-DreleaseVersion=repo-4504-core-61-1 -DdevelopmentVersion=7.5.6-SNAPSHOT release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests -DreleaseVersion=repo-4504-core-61-1 -DdevelopmentVersion=7.5.6-SNAPSHOT release:clean release:prepare release:perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
   only:
     - master
     - /support\/.*/
+    - fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1
 
 install: travis_retry mvn install -DskipTests=true -B -V
 
@@ -34,7 +35,7 @@ jobs:
         - java -jar wss-unified-agent.jar -apiKey ${WHITESOURCE_API_KEY} -c .wss-unified-agent.config
     - stage: release
       name: "Push to Nexus"
-      if: fork = false AND (branch = master OR branch =~ /support\/.*/) AND type != pull_request AND commit_message !~ /\[no-release\]/
+      if: fork = false AND (branch = fix/REPO-450_Upgrade_cxf-rt-transports-http_6.1) AND type != pull_request AND commit_message !~ /\[no-release\]/
       before_install:
         - "cp .travis.settings.xml $HOME/.m2/settings.xml"
       script:
@@ -43,4 +44,4 @@ jobs:
         # Add email to link commits to user
         - git config user.email "${GIT_EMAIL}"
         # Skip building of release commits
-        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests release:clean release:prepare release:perform
+        - mvn --batch-mode -q -DscmCommentPrefix="[maven-release-plugin][skip ci] " -Dusername="${GIT_USERNAME}" -Dpassword="${GIT_PASSWORD}" -DskipTests -Darguments=-DskipTests 		-DreleaseVersion=repo-4504-core-61-1 -DdevelopmentVersion=7.5.6-SNAPSHOT release:clean release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>repo-4504-core-61-1</version>
+   <version>7.5.6-SNAPSHOT</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>repo-4504-core-61-1</tag>
+      <tag>HEAD</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
       <version>10</version>
    </parent>   
    <artifactId>alfresco-core</artifactId>
-   <version>7.5.6-SNAPSHOT</version>
+   <version>repo-4504-core-61-1</version>
    <name>Alfresco Core</name>
    <description>Alfresco core libraries and utils</description>
 
@@ -15,7 +15,7 @@
       <connection>scm:git:https://github.com/Alfresco/alfresco-core.git</connection>
       <developerConnection>scm:git:https://github.com/Alfresco/alfresco-core.git</developerConnection>
       <url>https://github.com/Alfresco/alfresco-core</url>
-      <tag>HEAD</tag>
+      <tag>repo-4504-core-61-1</tag>
   </scm>
 
    <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <dependency>
          <groupId>com.sun.xml.bind</groupId>
          <artifactId>jaxb-xjc</artifactId>
-         <version>2.3.1</version>
+         <version>2.3.2</version>
       </dependency>
       <dependency>
          <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
Updating the cxf libraries caused a duplicate library error in acs-packaging.
Updating jaxb-xjc to version 2.3.2 fixes this.