### PR TITLE
REPO-4884 - Remove library org.apache.httpcomponents:httpclient from …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,6 @@
          <artifactId>joda-time</artifactId>
          <version>2.10.5</version>
       </dependency>
-      <dependency>
-         <groupId>org.apache.httpcomponents</groupId>
-         <artifactId>httpclient</artifactId>
-         <version>4.5.10</version>
-      </dependency>
 
       <!-- provided dependencies -->
       <dependency>


### PR DESCRIPTION
…alfresco-core
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

