### PR TITLE
REPO-4885 - Remove library org.mybatis:mybatis-spring from alfresco-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,17 +74,6 @@
          <version>3.3.0</version>
       </dependency>
       <dependency>
-         <groupId>org.mybatis</groupId>
-         <artifactId>mybatis-spring</artifactId>
-         <version>1.2.5</version>
-         <exclusions>
-            <exclusion>
-               <groupId>org.mybatis</groupId>
-               <artifactId>mybatis</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-      <dependency>
          <groupId>log4j</groupId>
          <artifactId>log4j</artifactId>
          <version>1.2.17</version>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

