### PR TITLE
REPO-4886 - Remove library org.mybatis:mybatis from alfresco-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
       </dependency>
       <dependency>
          <groupId>org.mybatis</groupId>
-         <artifactId>mybatis</artifactId>
-         <version>3.3.0</version>
-      </dependency>
-      <dependency>
-         <groupId>org.mybatis</groupId>
          <artifactId>mybatis-spring</artifactId>
          <version>1.2.5</version>
          <exclusions>


### PR DESCRIPTION
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

