### PR TITLE
REPO-4887 - Remove library org.springframework:spring-context-support…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
          <version>${dependency.spring.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.springframework</groupId>
-         <artifactId>spring-context-support</artifactId>
-         <version>${dependency.spring.version}</version>
-      </dependency>
-      <dependency>
          <groupId>org.quartz-scheduler</groupId>
          <artifactId>quartz</artifactId>
          <version>2.3.2</version>


### PR DESCRIPTION
… from alfresco-core
Regarding the issue REPO-4695, this is a library that can be removed according with the analysis done.

